### PR TITLE
Fix profile picture persistence after refresh

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -11,9 +11,8 @@ urlpatterns = [
     path('', include('marketplace.urls')),
 ]
 
-# This handles user-uploaded media files
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# Serve user-uploaded media files in both development and simple production setups
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # This new line will handle the admin static files
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Always serve user-uploaded media files to ensure profile pictures persist after page refresh.

The previous configuration only served media files when `settings.DEBUG` was `True`. This caused uploaded profile pictures to appear initially but revert to default upon refresh (or when `DEBUG` was `False`), as the browser could no longer fetch the image from the `/media/` URL, leading to a 404. Removing the `DEBUG` check ensures media files are consistently served.