### PR TITLE
Fix missing Profile exception check

### DIFF
--- a/marketplace/consumers.py
+++ b/marketplace/consumers.py
@@ -5,7 +5,7 @@ from channels.db import database_sync_to_async
 from django.contrib.auth.models import User
 from django.db.models import Q
 from django.utils import timezone
-from .models import Conversation, Message
+from .models import Conversation, Message, Profile
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 
@@ -15,7 +15,8 @@ def update_user_last_seen(user):
         try:
             user.profile.last_seen = timezone.now()
             user.profile.save()
-        except user.profile.DoesNotExist:
+        except Profile.DoesNotExist:
+            # If the user somehow has no profile, silently skip the update
             pass
 
 @database_sync_to_async


### PR DESCRIPTION
## Summary
- import `Profile` model in the websocket consumer
- catch `Profile.DoesNotExist` when updating `last_seen`

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6875dffe1594833099a4168c50af798c